### PR TITLE
TECH Fix issue with multiple handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 [![codecov](https://codecov.io/gh/transcovo/go-chpr-worker/branch/master/graph/badge.svg)](https://codecov.io/gh/transcovo/go-chpr-worker)
 
 
-This library packages everything you need to implement a worker that
-takes tasks from AMQP messages.
+This library packages everything you need to implement a worker that takes tasks
+from AMQP messages.
 
 ## Example
 
-The example below borrowed to pidget shows how to use it to implement a typical
-usecase:
+The example below shows how to implement a typical usecase:
 
 ```go
 // listen to os Signals to allow a graceful shutdown
@@ -16,16 +15,31 @@ sigs := make(chan os.Signal)
 signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 // create the worker with the desired configuration
-// note: you really don't have to use viper :=)
 w := worker.AmqpWorker{
-    AmqpURL:              viper.GetString("amqp.url"),
-    Exchange:             viper.GetString("amqp.common.exchange"),
-    Queue:                viper.GetString("amqp.sendWorker.queue"),
-    ChannelPrefetchCount: viper.GetInt("send_worker.amqpPrefetchCount"),
-    ConsumerTag:          "",
-    Handlers:             getAmqpHandlers(db),
-}
+		AmqpURL:              "amqp://guest:guest@localhost:5672",
+		Exchange:             "bus",
+		Queue:                "application.worker",
+		ChannelPrefetchCount: 100,
+		ConsumerTag:          "",
+		Handlers: []worker.AmqpConsumer{
+			{
+				RoutingKey: "routing.key",
+				Handler:    myHandler,
+			},
+		},
+	}
 
 // start the worker
 w.Start(sigs)
 ```
+
+### Notes
+
+The `Queue` field of the `AmqpWorker` struct must be unique for each worker to
+avoid misrouting messages to the wrong `AmqpConsumer`.
+
+We generate a queue name using both `Queue` and the `RoutingKey` for
+each `AmqpConsumer`.
+
+So if we take the previous example the generated queue name will be
+`application.worker.routing.key`


### PR DESCRIPTION
Creates a new channel and queue for each routing key/handler.

The generated queue name for each comsumer is following the format "queueName.RoutingKey"

Also update README 👍 

Fix #1