### PR TITLE
Clean code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ w := worker.AmqpWorker{
 				Handler:    myHandler,
 			},
 		},
+		ChannelCloseTimeout: 1*time.Second,
 	}
 
 // start the worker

--- a/worker_test.go
+++ b/worker_test.go
@@ -90,7 +90,6 @@ var _ = Describe("Worker", func() {
 			res := getChannel(func() (*amqp.Channel, error) {
 				return channel, nil
 			})
-
 			Expect(res).To(Equal(channel))
 		})
 
@@ -212,7 +211,6 @@ var _ = Describe("Worker", func() {
 	})
 
 	Describe("#bindQueue()", func() {
-
 		It("should bind queue", func() {
 			var name, key, exchange string
 			var noWait bool


### PR DESCRIPTION
In order to add more feature, I wanted to simplify a bit the code of the Start method.

The contract must be the same. I decided to keep the same behavior.
Basically, what you need to know is : when we receive an interrupt or when an error occurs, we close the channels and connection and wait for the handlers to finish receiving messages.
We don't wait for all the messages to have been processed. It can be added next pretty easily but changes the contract a bit.