### PR TITLE
TRAN-27112 - chore(log|metrics): Removing ack event (unused data)

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -300,8 +300,6 @@ func handleDeliveryWithRetry(msg amqp.Delivery, handler AmqpHandler, waitGroup *
 		"msgBody": string(msg.Body),
 	})
 	if err == nil {
-		metrics.Increment("amqp.msg.ack")
-		scopeLogger.Info("[lib.amqp#handleDeliveryWithRetry] Acking message")
 		msg.Ack(false)
 		return
 	}


### PR DESCRIPTION
## Jira ticket

https://transcovo.atlassian.net/browse/TRAN-27112

## Goal

Removing `ack` log and metric, because it generates a lot of them without really being used.